### PR TITLE
Removed PHP 5.6 in travis build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: trusty
 sudo: false
 
 php:
-  - 5.6
   - 7.0
   - 7.1
 


### PR DESCRIPTION
Removing support for PHP5.6